### PR TITLE
Missing dependencies.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,5 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
To enable jetifier, add these two lines to your gradle.properties file. This fixed the build error.